### PR TITLE
Switched to small lodash npm packages instead of importing lodash

### DIFF
--- a/lib/mongo-object.js
+++ b/lib/mongo-object.js
@@ -1,5 +1,6 @@
-import _ from 'lodash';
-
+import each from 'lodash.foreach';
+import isEmpty from 'lodash.isempty';
+import isObject from 'lodash.isobject';
 const REMOVED_MARKER = '______MONGO_OBJECT_REMOVED______';
 
 export default class MongoObject {
@@ -91,7 +92,7 @@ export default class MongoObject {
         }
 
         // Loop
-        _.each(val, (v, i) => {
+        each(val, (v, i) => {
           if (currentPosition) _this._arrayItemPositions.push(`${currentPosition}[${i}]`);
           parseObj(
             _this,
@@ -108,7 +109,7 @@ export default class MongoObject {
         // but always for the passed-in object, even if it
         // is a custom object.
 
-        if (currentPosition && !_.isEmpty(val)) {
+        if (currentPosition && !isEmpty(val)) {
           // Mark positions with objects that should be ignored when we want endpoints only
           _this._parentPositions.push(currentPosition);
 
@@ -117,7 +118,7 @@ export default class MongoObject {
         }
 
         // Loop
-        _.each(val, (v, k) => {
+        each(val, (v, k) => {
           if (v === void 0) {
             delete val[k];
           } else if (k !== '$slice') {
@@ -158,7 +159,7 @@ export default class MongoObject {
     if (typeof func !== 'function') throw new Error('filter requires a loop function');
 
     const updatedValues = {};
-    _.each(this._affectedKeys, (affectedKey, position) => {
+    each(this._affectedKeys, (affectedKey, position) => {
       if (endPointsOnly && this._parentPositions.indexOf(position) > -1) return; // Only endpoints
       func.call({
         value: this.getValueForPosition(position),
@@ -177,7 +178,7 @@ export default class MongoObject {
     });
 
     // Actually update/remove values as instructed
-    _.each(updatedValues, (newVal, position) => {
+    each(updatedValues, (newVal, position) => {
       this.setValueForPosition(position, newVal);
     });
   }
@@ -551,7 +552,7 @@ export default class MongoObject {
   removeArrayItems() {
     // Traverse and pull out removed array items at this point
     function traverse(obj) {
-      _.each(obj, (val, indexOrProp) => {
+      each(obj, (val, indexOrProp) => {
         // Move deeper into the object
         const next = obj[indexOrProp];
 
@@ -599,7 +600,7 @@ export default class MongoObject {
     keepArrays: keepArrays = false,
   } = {}) {
     const newObj = {};
-    _.each(this._affectedKeys, (affectedKey, position) => {
+    each(this._affectedKeys, (affectedKey, position) => {
       if (typeof affectedKey === 'string' &&
         (keepArrays === true && this._positionsInsideArrays.indexOf(position) === -1 && this._objectPositions.indexOf(position) === -1) ||
         (keepArrays !== true && this._parentPositions.indexOf(position) === -1)
@@ -710,7 +711,7 @@ export default class MongoObject {
 
   static _keyToPosition(key, wrapAll) {
     let position = '';
-    _.each(key.split('.'), (piece, i) => {
+    each(key.split('.'), (piece, i) => {
       if (i === 0 && !wrapAll) {
         position += piece;
       } else {
@@ -748,13 +749,13 @@ export default class MongoObject {
    */
   static cleanNulls(doc, isArray, keepEmptyStrings) {
     const newDoc = isArray ? [] : {};
-    _.each(doc, (val, key) => {
+    each(doc, (val, key) => {
       if (!Array.isArray(val) && MongoObject.isBasicObject(val)) {
         val = MongoObject.cleanNulls(val, false, keepEmptyStrings); // Recurse into plain objects
-        if (!_.isEmpty(val)) newDoc[key] = val;
+        if (!isEmpty(val)) newDoc[key] = val;
       } else if (Array.isArray(val)) {
         val = MongoObject.cleanNulls(val, true, keepEmptyStrings); // Recurse into non-typed arrays
-        if (!_.isEmpty(val)) newDoc[key] = val;
+        if (!isEmpty(val)) newDoc[key] = val;
       } else if (!isNullUndefinedOrEmptyString(val)) {
         newDoc[key] = val;
       } else if (keepEmptyStrings && typeof val === 'string' && val.length === 0) {
@@ -776,7 +777,7 @@ export default class MongoObject {
     const nulls = {};
 
     // Loop through the flat doc
-    _.each(flatDoc, (val, key) => {
+    each(flatDoc, (val, key) => {
       if (
         val === null ||
         val === undefined ||
@@ -818,8 +819,8 @@ export default class MongoObject {
     flatDoc = MongoObject.cleanNulls(flatDoc, false, keepEmptyStrings);
 
     const modifier = {};
-    if (!_.isEmpty(flatDoc)) modifier.$set = flatDoc;
-    if (!_.isEmpty(nulls)) modifier.$unset = nulls;
+    if (!isEmpty(flatDoc)) modifier.$set = flatDoc;
+    if (!isEmpty(nulls)) modifier.$unset = nulls;
     return modifier;
   }
 
@@ -855,13 +856,13 @@ export default class MongoObject {
    */
   static expandObj(doc) {
     const newDoc = {};
-    _.each(doc, (val, key) => {
+    each(doc, (val, key) => {
       const subkeys = key.split('.');
       const subkeylen = subkeys.length;
       let current = newDoc;
       for (let i = 0; i < subkeylen; i++) {
         const subkey = subkeys[i];
-        if (typeof current[subkey] !== 'undefined' && !_.isObject(current[subkey])) {
+        if (typeof current[subkey] !== 'undefined' && !isObject(current[subkey])) {
           break; // Already set for some reason; leave it alone
         }
 
@@ -872,7 +873,7 @@ export default class MongoObject {
           // See if the next piece is a number
           let nextPiece = subkeys[i + 1];
           nextPiece = parseInt(nextPiece, 10);
-          if (isNaN(nextPiece) && !_.isObject(current[subkey])) {
+          if (isNaN(nextPiece) && !isObject(current[subkey])) {
             current[subkey] = {};
           } else if (!isNaN(nextPiece) && !Array.isArray(current[subkey])) {
             current[subkey] = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-object",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "An API for interacting with a MongoDB document or modifier",
   "author": "Eric Dobbertin <aldeed@gmail.com>",
   "license": "MIT",
@@ -27,7 +27,9 @@
     "test:watch": "npm test -- --watch"
   },
   "dependencies": {
-    "lodash": "^4.5.1"
+    "lodash.foreach": "^4.5.0",
+    "lodash.isempty": "^4.4.0",
+    "lodash.isobject": "^3.0.2"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",


### PR DESCRIPTION
At the moment this library import the whole lodash library but only uses three methods. This only imports the required lodash functions.

The minor version was also increased for a new release.