### PR TITLE
replace for-of with forEach

### DIFF
--- a/lib/mongo-object.js
+++ b/lib/mongo-object.js
@@ -335,7 +335,7 @@ export default class MongoObject {
     // position string, and then return whatever is at that new position in
     // the original object.
     const positions = this.getPositionsForGenericKey(`${key}.$`);
-    for (const pos of positions) {
+    positions.forEach((pos) => {
       let value = this.getValueForPosition(pos);
       if (value === undefined) {
         const parentPosition = pos.slice(0, pos.lastIndexOf('['));
@@ -348,7 +348,7 @@ export default class MongoObject {
           operator: extractOp(pos),
         };
       }
-    }
+    });
   }
 
   /**
@@ -361,12 +361,12 @@ export default class MongoObject {
    * Example: 'foo[bar][0]'
    */
   getPositionForKey(key) {
-    for (const position of Object.getOwnPropertyNames(this._affectedKeys)) {
+    Object.getOwnPropertyNames(this._affectedKeys).forEach((position) => {
       // We return the first one we find. While it's
       // possible that multiple update operators could
       // affect the same non-generic key, we'll assume that's not the case.
       if (this._affectedKeys[position] === key) return position;
-    }
+    });
   }
 
   /**
@@ -438,11 +438,11 @@ export default class MongoObject {
    * Removes anything that affects any of the generic keys in the list
    */
   removeGenericKeys(keys) {
-    for (const position of Object.getOwnPropertyNames(this._genericAffectedKeys)) {
+    Object.getOwnPropertyNames(this._genericAffectedKeys).forEach((position) => {
       if (keys.indexOf(this._genericAffectedKeys[position]) > -1) {
         this.removeValueForPosition(position);
       }
-    }
+    });
   }
 
   /**
@@ -453,11 +453,11 @@ export default class MongoObject {
    * Removes anything that affects the requested generic key
    */
   removeGenericKey(key) {
-    for (const position of Object.getOwnPropertyNames(this._genericAffectedKeys)) {
+    Object.getOwnPropertyNames(this._genericAffectedKeys).forEach((position) => {
       if (this._genericAffectedKeys[position] === key) {
         this.removeValueForPosition(position);
       }
-    }
+    });
   }
 
   /**
@@ -470,11 +470,11 @@ export default class MongoObject {
   removeKey(key) {
     // We don't use getPositionForKey here because we want to be sure to
     // remove for all positions if there are multiple.
-    for (const position of Object.getOwnPropertyNames(this._affectedKeys)) {
+    Object.getOwnPropertyNames(this._affectedKeys).forEach((position) => {
       if (this._affectedKeys[position] === key) {
         this.removeValueForPosition(position);
       }
-    }
+    });
   }
 
   /**
@@ -485,9 +485,7 @@ export default class MongoObject {
    * Removes anything that affects any of the non-generic keys in the list
    */
   removeKeys(keys) {
-    for (const key of keys) {
-      this.removeKey(key);
-    }
+    keys.forEach(key => this.removeKey(key));
   }
 
   /**
@@ -501,21 +499,17 @@ export default class MongoObject {
   filterGenericKeys(test) {
     const checkedKeys = [];
     const keysToRemove = [];
-    for (const position in this._genericAffectedKeys) {
-      if (this._genericAffectedKeys.hasOwnProperty(position)) {
-        const genericKey = this._genericAffectedKeys[position];
-        if (checkedKeys.indexOf(genericKey) === -1) {
-          checkedKeys.push(genericKey);
-          if (genericKey && !test(genericKey)) {
-            keysToRemove.push(genericKey);
-          }
+    Object.getOwnPropertyNames(this._genericAffectedKeys).forEach((position) => {
+      const genericKey = this._genericAffectedKeys[position];
+      if (checkedKeys.indexOf(genericKey) === -1) {
+        checkedKeys.push(genericKey);
+        if (genericKey && !test(genericKey)) {
+          keysToRemove.push(genericKey);
         }
       }
-    }
+    });
 
-    for (const key of keysToRemove) {
-      this.removeGenericKey(key);
-    }
+    keysToRemove.forEach(key => this.removeGenericKey(key));
   }
 
   /**
@@ -530,11 +524,11 @@ export default class MongoObject {
   setValueForKey(key, val) {
     // We don't use getPositionForKey here because we want to be sure to
     // set the value for all positions if there are multiple.
-    for (const position of Object.getOwnPropertyNames(this._affectedKeys)) {
+    Object.getOwnPropertyNames(this._affectedKeys).forEach((position) => {
       if (this._affectedKeys[position] === key) {
         this.setValueForPosition(position, val);
       }
-    }
+    });
   }
 
   /**
@@ -549,11 +543,11 @@ export default class MongoObject {
   setValueForGenericKey(key, val) {
     // We don't use getPositionForKey here because we want to be sure to
     // set the value for all positions if there are multiple.
-    for (const position of Object.getOwnPropertyNames(this._genericAffectedKeys)) {
+    Object.getOwnPropertyNames(this._genericAffectedKeys).forEach((position) => {
       if (this._genericAffectedKeys[position] === key) {
         this.setValueForPosition(position, val);
       }
-    }
+    });
   }
 
   removeArrayItems() {
@@ -638,9 +632,9 @@ export default class MongoObject {
    * Returns true if the generic key is affected by this object
    */
   affectsGenericKey(key) {
-    for (const position of Object.getOwnPropertyNames(this._genericAffectedKeys)) {
+    Object.getOwnPropertyNames(this._genericAffectedKeys).forEach((position) => {
       if (this._genericAffectedKeys[position] === key) return true;
-    }
+    });
 
     return false;
   }
@@ -653,10 +647,10 @@ export default class MongoObject {
    * Like affectsGenericKey, but will return true if a child key is affected
    */
   affectsGenericKeyImplicit(key) {
-    for (const position of Object.getOwnPropertyNames(this._genericAffectedKeys)) {
+    Object.getOwnPropertyNames(this._genericAffectedKeys).forEach((position) => {
       const affectedKey = this._genericAffectedKeys[position];
       if (genericKeyAffectsOtherGenericKey(key, affectedKey)) return true;
-    }
+    });
 
     return false;
   }


### PR DESCRIPTION
This fixes an issue with React Native recompiling already compiled for-of loops and throwing errors. I've previously submitted a fix on the simple-schema-js repo, which fixed the issue when cleaning documents, but I didn't dive into validating and inserting objects which uses this library and the issue crops up again.