### PR TITLE
improve performance and fix issue with nested objects

### DIFF
--- a/lib/mongo-object.js
+++ b/lib/mongo-object.js
@@ -22,6 +22,7 @@ export default class MongoObject {
     const blackboxKeys = this._blackboxKeys;
 
     this._affectedKeys = {};
+    this._affectedPositions = {};
     this._genericAffectedKeys = {};
     this._positionsByGenericKey = {};
     this._positionsThatCreateGenericKey = {};
@@ -74,6 +75,7 @@ export default class MongoObject {
         // Mark that this position affects this generic and non-generic key
         if (currentPosition) {
           self._affectedKeys[currentPosition] = affectedKey;
+          self._affectedPositions[affectedKey] = currentPosition;
           self._genericAffectedKeys[currentPosition] = affectedKeyGeneric;
 
           const positionInfo = {
@@ -263,6 +265,7 @@ export default class MongoObject {
         }
 
         this._affectedKeys[position] = affectedKey;
+        this._affectedPositions[affectedKey] = position;
       } else { // Otherwise attempt to keep moving deeper into the object.
         // If we're setting (as opposed to deleting) a key and we hit a place
         // in the ancestor chain where the keys are not yet created, create them.
@@ -271,6 +274,9 @@ export default class MongoObject {
           let nextPiece = subkeys[i + 1];
           nextPiece = parseInt(nextPiece, 10);
           current[subkey] = Number.isNaN(nextPiece) ? {} : [];
+          createdObjectsOrArrays = true;
+        }
+        else if (isEmpty(current[subkey])) {
           createdObjectsOrArrays = true;
         }
 
@@ -366,14 +372,7 @@ export default class MongoObject {
    * Example: 'foo[bar][0]'
    */
   getPositionForKey(key) {
-    const positions = Object.getOwnPropertyNames(this._affectedKeys);
-    for (let index = 0; index < positions.length; index++) {
-      const position = positions[index];
-      // We return the first one we find. While it's
-      // possible that multiple update operators could
-      // affect the same non-generic key, we'll assume that's not the case.
-      if (this._affectedKeys[position] === key) return position;
-    }
+    return this._affectedPositions[key];
   }
 
   /**

--- a/lib/mongo-object.test.js
+++ b/lib/mongo-object.test.js
@@ -550,4 +550,15 @@ describe('MongoObject', () => {
       },
     }, { $set: { bar: 'foo' } }, '$set[bar]', 'bar', 'foo', '$set');
   });
+
+  it('should behave correctly when an empty nested object is provided', function () {
+    const mDoc = new MongoObject({
+      flex: {
+        dev: {}
+      }
+    });
+    mDoc.setValueForPosition("flex[dev][key]", "test");
+
+    expect(mDoc.getFlatObject()).toEqual({ "flex.dev.key": "test" });
+  });
 });


### PR DESCRIPTION
This makes two changes:

1. improves the performance of `getPositionForKey` substantially by tracking them in the same way as affectedKeys
2. fix a bug (with a test) when an empty object is modified via `setValueForPosition`